### PR TITLE
Fix case statements to remove warnings for 0.7.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,9 +11,9 @@
     "tools"
   ],
   "dependencies": {
-    "purescript-strings": "~0.5.3",
-    "purescript-console": "~0.1.0",
-    "purescript-aff": "~0.11.0",
-    "purescript-exceptions": "~0.3.0"
+    "purescript-strings": "^0.5.3",
+    "purescript-console": "^0.1.0",
+    "purescript-aff": "^0.11.0",
+    "purescript-exceptions": "^0.3.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -11,9 +11,10 @@
     "tools"
   ],
   "dependencies": {
-    "purescript-strings": "^0.5.3",
     "purescript-console": "^0.1.0",
     "purescript-aff": "^0.11.0",
-    "purescript-exceptions": "^0.3.0"
+    "purescript-exceptions": "^0.3.0",
+    "purescript-strings": "^0.7.0",
+    "purescript-prelude": "^0.1.2"
   }
 }

--- a/src/Test/Spec.purs
+++ b/src/Test/Spec.purs
@@ -37,7 +37,6 @@ instance eqResult :: Eq Result where
   eq Success Success = true
   eq (Failure _) (Failure _) = true
   eq _ _ = false
-  eq r1 r2 = not (r1 == r2)
 
 instance showGroup :: Show Group where
   show (Describe name groups) = "Describe " ++ show name ++ " " ++ show groups

--- a/src/Test/Spec/Reporter.purs
+++ b/src/Test/Spec/Reporter.purs
@@ -22,8 +22,8 @@ instance eqEntry :: Eq Entry where
   eq (It n1 S.Success) (It n2 S.Success) = n1 == n2
   eq (It n1 (S.Failure e1)) (It n2 (S.Failure e2)) =
     n1 == n2 && (message e1) == (message e2)
-  eq (It n1 _) (It n2 _) = false
   eq (Pending n1) (Pending n2) = n1 == n2
+  eq _ _ = false
 
 instance showEntry :: Show Entry where
   show (Describe names) = "Describe \"" ++ (intercalate " » " names) ++ "\""


### PR DESCRIPTION
PureScript 0.7.2 seems to have added warnings for redundancy and incompleteness in case statements.