### PR TITLE
Exit NodeJS process on success as well as failure.

### DIFF
--- a/src/Test/Spec/Runner.purs
+++ b/src/Test/Spec/Runner.purs
@@ -5,7 +5,6 @@ module Test.Spec.Runner (
 
 import Prelude
 
-import Control.Monad             (when)
 import Control.Monad.Aff         (runAff)
 import Control.Monad.Eff         (Eff())
 import Control.Monad.Eff.Console (CONSOLE(), print)
@@ -22,7 +21,9 @@ foreign import exit :: forall eff. Int -> Eff (process :: Process | eff) Unit
 
 -- Runs the tests and invoke all reporters.
 -- If run in a NodeJS environment any failed test will cause the
--- process to exit with a non-zero exit code.
+-- process to exit with a non-zero exit code. On success it will
+-- exit with a zero exit code explicitly, so passing integration tests that still have
+-- connections open can run in CI successfully.
 run :: forall e.
     Array (Reporter (process :: Process, console :: CONSOLE | e))
     -> Spec (process :: Process, console :: CONSOLE | e) Unit
@@ -32,5 +33,12 @@ run rs spec = do
     (\err -> do withAttrs [31] $ print err
                 exit 1)
     (\results -> do sequence_ (map (\f -> f results) rs)
-                    when (not $ successful results) $ exit 1)
+                    exitWithCode (successful results))
     (collect spec)
+
+exitWithCode :: forall t5.
+  Boolean
+  -> Eff ( process :: Process | t5) Unit
+exitWithCode success = exit (code success)
+  where code true  = 0
+	code false = 1

--- a/src/Test/Spec/Runner.purs
+++ b/src/Test/Spec/Runner.purs
@@ -33,12 +33,8 @@ run rs spec = do
     (\err -> do withAttrs [31] $ print err
                 exit 1)
     (\results -> do sequence_ (map (\f -> f results) rs)
-                    exitWithCode (successful results))
+                    if (successful results)
+                      then exit 0
+                      else exit 1)
     (collect spec)
 
-exitWithCode :: forall t5.
-  Boolean
-  -> Eff ( process :: Process | t5) Unit
-exitWithCode success = exit (code success)
-  where code true  = 0
-	code false = 1


### PR DESCRIPTION
Behaviour was already there for failure, now also for success.

For integration tests. If there are connections open, NodeJS won't exit.

e.g.
http://stackoverflow.com/questions/18046639/node-process-doesnt-exit-after-firebase-once

I don't know how to write a test for this at the moment, since the
behaviour does an 'exit 0'.