### PR TITLE
Adopt the uppercase convention for the process effect name.

### DIFF
--- a/src/Test/Spec/Runner.purs
+++ b/src/Test/Spec/Runner.purs
@@ -1,5 +1,5 @@
 module Test.Spec.Runner (
-  Process(..),
+  PROCESS(..),
   run
   ) where
 
@@ -15,9 +15,9 @@ import Test.Spec.Console  (withAttrs)
 import Test.Spec.Summary  (successful)
 import Test.Spec.Reporter (Reporter())
 
-foreign import data Process :: !
+foreign import data PROCESS :: !
 
-foreign import exit :: forall eff. Int -> Eff (process :: Process | eff) Unit
+foreign import exit :: forall eff. Int -> Eff (process :: PROCESS | eff) Unit
 
 -- Runs the tests and invoke all reporters.
 -- If run in a NodeJS environment any failed test will cause the
@@ -25,9 +25,9 @@ foreign import exit :: forall eff. Int -> Eff (process :: Process | eff) Unit
 -- exit with a zero exit code explicitly, so passing integration tests that still have
 -- connections open can run in CI successfully.
 run :: forall e.
-    Array (Reporter (process :: Process, console :: CONSOLE | e))
-    -> Spec (process :: Process, console :: CONSOLE | e) Unit
-    -> Eff  (process :: Process, console :: CONSOLE | e) Unit
+    Array (Reporter (process :: PROCESS, console :: CONSOLE | e))
+    -> Spec (process :: PROCESS, console :: CONSOLE | e) Unit
+    -> Eff  (process :: PROCESS, console :: CONSOLE | e) Unit
 run rs spec = do
   runAff
     (\err -> do withAttrs [31] $ print err
@@ -37,4 +37,3 @@ run rs spec = do
                       then exit 0
                       else exit 1)
     (collect spec)
-

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -5,14 +5,14 @@ import Prelude
 import Control.Monad.Eff         (Eff())
 import Control.Monad.Eff.Console (CONSOLE())
 
-import Test.Spec.Runner           (Process(), run)
+import Test.Spec.Runner           (PROCESS(), run)
 import Test.Spec.Reporter.Console (consoleReporter)
 
 import Test.Spec.ReporterSpec   (reporterSpec)
 import Test.Spec.RunnerSpec     (runnerSpec)
 import Test.Spec.AssertionSpec  (assertionSpec)
 
-main :: forall eff. Eff (console :: CONSOLE, process :: Process | eff) Unit
+main :: forall eff. Eff (console :: CONSOLE, process :: PROCESS | eff) Unit
 main = run [consoleReporter] do
   runnerSpec
   reporterSpec


### PR DESCRIPTION
All the purescript core libraries use UPPERCASE names for effects.