### PR TITLE
Depend on all packages < 1.0.0, bump to 0.7.5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-spec",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "ignore": [
     "**/.*",
     "bower_components",
@@ -15,12 +15,12 @@
     "url": "git://github.com/owickstrom/purescript-spec.git"
   },
   "dependencies": {
-    "purescript-console": ">=0.1.0",
-    "purescript-aff": ">=0.13.0",
-    "purescript-exceptions": ">=0.3.0",
-    "purescript-strings": ">=0.7.0",
-    "purescript-prelude": ">=0.1.2",
-    "purescript-transformers": "~0.8.2",
-    "purescript-node-process": "~0.4.1"
+    "purescript-console": "^0.1.0",
+    "purescript-aff": "^0.13.0",
+    "purescript-exceptions": "^0.3.0",
+    "purescript-strings": "^0.7.0",
+    "purescript-prelude": "^0.1.2",
+    "purescript-transformers": "^0.8.2",
+    "purescript-node-process": "^0.4.1"
   }
 }


### PR DESCRIPTION
Changed all dependencies to use '^' instead of '>=', so bower does not
go searching for 1.0.0 packages and their dependencies.

Also bumped version to 0.7.5, so this can go on to bower soon,
hopefully.

(I finally read:
https://github.com/npm/node-semverhttps://github.com/npm/node-semver
).

It looks like the build (and a local install) failed because one of our
dependencies' dependencies does not yet exist in the right version.

Separate minor version, so things that depend on this (two of my
packages) that can't yet be upgraded because not all their (transitive)
dependencies exist in the right version yet.

I guess upgrading to all 1.0.0+ dependencies should be done in a version
of purescript-spec that is also 1.0.0?