### PR TITLE
Implement the ".only" modifier from mocha

### DIFF
--- a/src/Test/Spec.purs
+++ b/src/Test/Spec.purs
@@ -4,8 +4,10 @@ module Test.Spec (
   Group(..),
   Spec(..),
   describe,
+  describeOnly,
   pending,
   it,
+  itOnly,
   collect
   ) where
 
@@ -17,10 +19,11 @@ import Control.Monad.State         (State(), modify, runState)
 import Data.Tuple                  (snd)
 
 type Name = String
+type Only = Boolean
 
 data Group t
-  = Describe Name (Array (Group t))
-  | It Name t
+  = Describe Boolean Name (Array (Group t))
+  | It Boolean Name t
   | Pending Name
 
 data Result
@@ -37,15 +40,15 @@ instance eqResult :: Eq Result where
   eq _ _ = false
 
 instance showGroup :: Show t => Show (Group t) where
-  show (Describe name groups) = "Describe " <> show name <> " " <> show groups
-  show (It name test) = "It " <> show name <> " " <> show test
+  show (Describe only name groups) = "Describe " <> show only <> " " <> show name <> " " <> show groups
+  show (It only name test) = "It " <> show only <> " " <> show name <> " " <> show test
   show (Pending name) = "Describe " <> show name
 
 instance eqGroup :: Eq t => Eq (Group t) where
-  eq (Describe n1 g1) (Describe n2 g2) = n1 == n2 && g1 == g2
-  eq (It n1 t1)       (It n2 t2)       = n1 == n2 && t1 == t2
-  eq (Pending n1)     (Pending n2)     = n1 == n2
-  eq _                _                = false
+  eq (Describe o1 n1 g1) (Describe o2 n2 g2) = o1 == o2 && n1 == n2 && g1 == g2
+  eq (It o1 n1 t1)       (It o2 n2 t2)       = o1 == o2 && n1 == n2 && t1 == t2
+  eq (Pending n1)        (Pending n2)        = n1 == n2
+  eq _                   _                   = false
 
 -- Specifications with unevaluated tests.
 type Spec r t = State (Array (Group (Aff r Unit))) t
@@ -58,13 +61,28 @@ collect r = snd $ runState r []
 --       DSL       --
 ---------------------
 
+-- | Combine a group of specs into a described hierarchy that either has the
+-- |"only" modifier applied or not.
+_describe :: forall r. Boolean
+         -> String
+         -> Spec r Unit
+         -> Spec r Unit
+_describe only name its =
+  modify (_ <> [Describe only name (collect its)]) $> unit
+
 -- | Combine a group of specs into a described hierarchy.
 describe :: forall r. String
          -> Spec r Unit
          -> Spec r Unit
-describe name its = do
-  modify $ \r -> r <> [Describe name (collect its)]
-  pure unit
+describe = _describe false
+
+-- | Combine a group of specs into a described hierarchy and mark it as the
+-- | only group to actually be evaluated. (useful for quickly narrowing down
+-- | on a set)
+describeOnly :: forall r. String
+         -> Spec r Unit
+         -> Spec r Unit
+describeOnly = _describe true
 
 -- | Create a pending spec.
 pending :: forall r. String
@@ -79,11 +97,23 @@ pending' :: forall r. String
         -> Spec r Unit
 pending' name _ = pending name
 
+-- | Create a spec with a description that either has the "only" modifier
+-- | applied or not
+_it :: forall r.  Boolean
+   -> String
+   -> Aff r Unit
+   -> Spec r Unit
+_it only description tests = modify (_ <> [It only description tests]) $> unit
+
 -- | Create a spec with a description.
 it :: forall r. String
    -> Aff r Unit
    -> Spec r Unit
-it description tests =
-  do
-    modify $ \p -> p <> [It description tests]
-    pure unit
+it = _it false
+
+-- | Create a spec with a description and mark it as the only one to
+-- | be run. (useful for quickly narrowing down on a single test)
+itOnly :: forall r. String
+   -> Aff r Unit
+   -> Spec r Unit
+itOnly = _it true

--- a/src/Test/Spec/Reporter.purs
+++ b/src/Test/Spec/Reporter.purs
@@ -38,9 +38,9 @@ type Entries = Map EntryPath (Array Entry)
 collapseAt :: EntryPath -> Group Result -> Entries
 collapseAt path group =
   case group of
-    S.It name result -> singleton path [It name result]
+    S.It _ name result -> singleton path [It name result]
     S.Pending name -> singleton path [Pending name]
-    S.Describe name groups -> collapseAllAt (path <> [name]) groups
+    S.Describe _ name groups -> collapseAllAt (path <> [name]) groups
 
 collapseAllAt :: EntryPath -> Array (Group Result) -> Entries
 collapseAllAt path = foldl (unionWith (<>)) empty <<< map (collapseAt path)

--- a/src/Test/Spec/Runner.purs
+++ b/src/Test/Spec/Runner.purs
@@ -39,20 +39,20 @@ runCatch group =
       pure (Describe only name results)
     Pending name -> pure (Pending name)
 
-findOnly :: forall r. Group r -> Maybe (Group r)
-findOnly g@(It true _ _) = pure g
-findOnly g@(Describe o _ gs) = findJust findOnly gs <|> if o then pure g
-                                                             else Nothing
-findOnly _ = Nothing
-
-findJust :: forall a. (a -> Maybe a) -> Array a -> Maybe a
-findJust f = foldl go Nothing
-  where
-  go Nothing x = f x
-  go acc _     = acc
-
 trim :: ∀ r. Array (Group r) -> Array (Group r)
 trim xs = fromMaybe xs (singleton <$> findJust findOnly xs)
+  where
+  findOnly :: Group r -> Maybe (Group r)
+  findOnly g@(It true _ _) = pure g
+  findOnly g@(Describe o _ gs) = findJust findOnly gs <|> if o then pure g
+                                                               else Nothing
+  findOnly _ = Nothing
+
+  findJust :: forall a. (a -> Maybe a) -> Array a -> Maybe a
+  findJust f = foldl go Nothing
+    where
+    go Nothing x = f x
+    go acc _     = acc
 
 runSpec :: forall r. Spec r Unit
          -> Aff r (Array (Group Result))

--- a/src/Test/Spec/Runner.purs
+++ b/src/Test/Spec/Runner.purs
@@ -26,14 +26,14 @@ runCatch :: forall r. Group (Aff r Unit)
          -> Aff r (Group Result)
 runCatch group =
   case group of
-    It name test -> do
-      let onError e = pure $ It name $ Failure e
-          onSuccess _ = pure $ It name Success
+    It only name test -> do
+      let onError e = pure $ It only name $ Failure e
+          onSuccess _ = pure $ It only name Success
       e <- attempt test
       either onError onSuccess e
-    Describe name groups -> do
+    Describe only name groups -> do
       results <- sequence (map runCatch groups)
-      pure (Describe name results)
+      pure (Describe only name results)
     Pending name -> pure (Pending name)
 
 

--- a/src/Test/Spec/Summary.purs
+++ b/src/Test/Spec/Summary.purs
@@ -21,10 +21,10 @@ instance monoidCount :: Monoid Summary where
 
 summarize :: Array (Group Result) -> Summary
 summarize = foldMap \g -> case g of
-    (It _ Success)     -> Count 1 0 0
-    (It _ (Failure _)) -> Count 0 1 0
-    (Pending _)        -> Count 0 0 1
-    (Describe _ dgs)   -> summarize dgs
+    (It _ _ Success)     -> Count 1 0 0
+    (It _ _ (Failure _)) -> Count 0 1 0
+    (Pending _)          -> Count 0 0 1
+    (Describe _ _ dgs)   -> summarize dgs
 
 successful :: Array (Group Result) -> Boolean
 successful groups =

--- a/test/Test/Spec/Fixtures.purs
+++ b/test/Test/Spec/Fixtures.purs
@@ -2,7 +2,7 @@ module Test.Spec.Fixtures where
 
 import Prelude
 
-import Test.Spec            (Spec, describe, it, pending)
+import Test.Spec            (Spec, describe, describeOnly, it, itOnly, pending)
 import Test.Spec.Assertions (shouldEqual)
 
 successTest :: forall r. Spec r Unit
@@ -33,7 +33,17 @@ duplicatedDescribeTest =
       describe "c" do
         it "second" do
           1 `shouldEqual` 1
-        
+
+onlyTest :: forall r. Spec r Unit
+onlyTest =
+  describeOnly "a" do
+    describe "b" do
+      it "works" do
+        1 `shouldEqual` 1
+    describe "c" do
+      itOnly "also works" do
+        1 `shouldEqual` 1
+
 failureTest :: forall r. Spec r Unit
 failureTest = it "fails" $ 1 `shouldEqual` 2
 

--- a/test/Test/Spec/Fixtures.purs
+++ b/test/Test/Spec/Fixtures.purs
@@ -34,14 +34,24 @@ duplicatedDescribeTest =
         it "second" do
           1 `shouldEqual` 1
 
-onlyTest :: forall r. Spec r Unit
-onlyTest =
+describeOnlyTest :: forall r. Spec r Unit
+describeOnlyTest =
   describeOnly "a" do
     describe "b" do
       it "works" do
         1 `shouldEqual` 1
     describe "c" do
-      itOnly "also works" do
+      it "also works" do
+        1 `shouldEqual` 1
+
+itOnlyTest :: forall r. Spec r Unit
+itOnlyTest =
+  describe "a" do
+    describe "b" do
+      itOnly "works" do
+        1 `shouldEqual` 1
+    describe "c" do
+      it "also works" do
         1 `shouldEqual` 1
 
 failureTest :: forall r. Spec r Unit

--- a/test/Test/Spec/RunnerSpec.purs
+++ b/test/Test/Spec/RunnerSpec.purs
@@ -8,11 +8,13 @@ import Test.Spec            ( Group(..)
                             , Result(..)
                             , Spec
                             , describe
-                            , it)
+                            , it
+                            , itOnly
+                            )
 import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Runner     (runSpec)
 
-import Test.Spec.Fixtures (successTest, sharedDescribeTest)
+import Test.Spec.Fixtures (successTest, sharedDescribeTest, onlyTest)
 
 runnerSpec :: forall r. Spec r Unit
 runnerSpec =
@@ -21,11 +23,15 @@ runnerSpec =
       describe "Runner" do
         it "collects \"it\" and \"pending\" in Describe groups" do
           results <- runSpec successTest
-          results `shouldEqual` [Describe "a" [Describe "b" [It "works" Success]]]
+          results `shouldEqual` [Describe false "a" [Describe false "b" [It false "works" Success]]]
         it "collects \"it\" and \"pending\" with shared Describes" do
           results <- runSpec sharedDescribeTest
-          results `shouldEqual` [Describe "a" [Describe "b" [It "works" Success],
-                                               Describe "c" [It "also works" Success]]]
-        it "supports async" do
+          results `shouldEqual` [Describe false "a" [Describe false "b" [It false "works" Success],
+                                                     Describe false "c" [It false "also works" Success]]]
+        it "collects \"it\" and \"pending\" with \"only\" modifier" do
+          results <- runSpec onlyTest
+          results `shouldEqual` [Describe true "a" [Describe false "b" [It false "works" Success],
+                                                    Describe false "c" [It true "also works" Success]]]
+        itOnly "supports async" do
           res <- later' 10 $ pure 1
           res `shouldEqual` 1

--- a/test/Test/Spec/RunnerSpec.purs
+++ b/test/Test/Spec/RunnerSpec.purs
@@ -14,7 +14,7 @@ import Test.Spec            ( Group(..)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Runner     (runSpec)
 
-import Test.Spec.Fixtures (successTest, sharedDescribeTest, onlyTest)
+import Test.Spec.Fixtures
 
 runnerSpec :: forall r. Spec r Unit
 runnerSpec =
@@ -28,10 +28,13 @@ runnerSpec =
           results <- runSpec sharedDescribeTest
           results `shouldEqual` [Describe false "a" [Describe false "b" [It false "works" Success],
                                                      Describe false "c" [It false "also works" Success]]]
-        it "collects \"it\" and \"pending\" with \"only\" modifier" do
-          results <- runSpec onlyTest
+        it "filters using \"only\" modifier on \"describe\" block" do
+          results <- runSpec describeOnlyTest
           results `shouldEqual` [Describe true "a" [Describe false "b" [It false "works" Success],
-                                                    Describe false "c" [It true "also works" Success]]]
-        itOnly "supports async" do
+                                                    Describe false "c" [It false "also works" Success]]]
+        it "filters using \"only\" modifier on \"it\" block" do
+          results <- runSpec itOnlyTest
+          results `shouldEqual` [It true "works" Success]
+        it "supports async" do
           res <- later' 10 $ pure 1
           res `shouldEqual` 1


### PR DESCRIPTION
Implement to new functions `describeOnly` and `itOnly` that will cause all other tests to be culled.
This is useful for quickly testing a subset of tests.

Refer to #16 for details.