### PR TITLE
Use 'dim' code in place of 'gray'

### DIFF
--- a/src/Test/Spec/Color.purs
+++ b/src/Test/Spec/Color.purs
@@ -18,19 +18,19 @@ data Color
  | Light
 
 code :: Color -> Int
-code Pass         = 90
+code Pass         = 2
 code Fail         = 31
 code Pending      = 36
 code Suite        = 0
 code ErrorTitle   = 0
 code ErrorMessage = 31
-code ErrorStack   = 90
+code ErrorStack   = 2
 code Checkmark    = 32
-code Fast         = 90
+code Fast         = 2
 code Medium       = 33
 code Slow         = 31
 code Green        = 32
-code Light        = 90
+code Light        = 2
 
 colored :: Color -> String -> String
 colored = _colored <<< code


### PR DESCRIPTION
Gray is invisible on the Solarized theme. Dim achieves a similar effect.
Dim is not supported on Windows but will be ignored afaik, rather than making the text invisible.
See https://github.com/eslint/eslint/pull/4885 for explanation and pictures.