### PR TITLE
export pending'

### DIFF
--- a/src/Test/Spec.purs
+++ b/src/Test/Spec.purs
@@ -8,6 +8,7 @@ module Test.Spec (
   describe,
   describeOnly,
   pending,
+  pending',
   it,
   itOnly,
   collect,


### PR DESCRIPTION
from [website](http://purescript-spec.wickstrom.tech/)

> Pending specs can also contain a spec body, just like with it. The difference is that the body will be ignored. Pending spec bodies are used to give a hint what the spec should assert in the future. Use pending' (note the ' at the end) to create a pending spec with a body.
> 
> ``` purescript
> pending' "calculates the answer to Life, the Universe and Everything" do
>   answerTo theUltimateQuestion `shouldBe` 42
> ```


but it's not exported