### PR TITLE
Compile tests to output, not output/tests

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -16,13 +16,13 @@ following command compiles all PureScript modules in `test` and `src`.
 
 
 ```bash
-psc -o output/tests 'test/**/*.purs' 'src/**/*.purs'
+psc -o output 'test/**/*.purs' 'src/**/*.purs'
 ```
 
 After that has finished, you can run the test program using NodeJS.
 
 ```
-NODE_PATH=output/tests node -e "require('Test.Main').main();"
+NODE_PATH=output node -e "require('Test.Main').main();"
 ```
 
 **NOTE:** A test program using `Test.Spec.Runner.run` cannot be browserified


### PR DESCRIPTION
I see this recommends compiling to output/tests. If doing that, the compilation wouldn't be able to use previously compilation artifacts as cached results to shorten compile times. I think we can safely compile to "output", no?