### PR TITLE
Remove `-js-timers`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,6 @@
     "purescript-transformers": "^3.0.0",
     "purescript-monoid": "^3.0.0",
     "purescript-foldable-traversable": "^3.0.0",
-    "purescript-js-timers": "^3.0.0",
     "purescript-pipes": "^4.0.0"
   }
 }

--- a/src/Test/Spec.purs
+++ b/src/Test/Spec.purs
@@ -21,7 +21,6 @@ import Control.Monad.Aff (Aff)
 import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.Eff.Exception (Error)
-import Control.Monad.Eff.Timer (TIMER)
 import Control.Monad.State (State, modify, execState, runState)
 import Data.Traversable (for, for_)
 import Data.Tuple (snd)
@@ -60,7 +59,6 @@ instance eqGroup :: Eq t => Eq (Group t) where
 
 -- Specifications with unevaluated tests.
 type SpecEffects e =  ( console :: CONSOLE
-                      , timer   :: TIMER
                       , avar    :: AVAR
                       | e)
 type Spec  eff t = State (Array (Group (Aff eff Unit))) t


### PR DESCRIPTION
Sorry for just opening a PR without a specific issue. Related to #61.

`delay` seems to do what we want.
We can avoid a JS specific dependency by using `delay`.